### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -160,7 +160,7 @@ pyairports=2.1.1=pypi_0
 pyarrow=17.0.0=pypi_0
 pyasn1=0.6.0=pypi_0
 pyasn1-modules=0.4.0=pypi_0
-pyautogen=0.3.1=pypi_0
+ag2=0.3.1=pypi_0
 pycountry=24.6.1=pypi_0
 pycparser=2.22=pypi_0
 pydantic=2.10.6=pypi_0


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
